### PR TITLE
fix: DR icons not appearing in linux

### DIFF
--- a/lua/contrib/FilmSimPanel.lua
+++ b/lua/contrib/FilmSimPanel.lua
@@ -192,7 +192,7 @@ darktable.register_lib(
             darktable.new_widget("button") {
                 tooltip = "DR100",
                 name = "film_sim_panel_dr100_button",
-                image = darktable.configuration.config_dir .. "/icons/dr100.svg",
+                image = darktable.configuration.config_dir .. "/icons/DR100.svg",
                 clicked_callback = function(source)
                     apply_style_to_selection("DR100")
                 end
@@ -200,7 +200,7 @@ darktable.register_lib(
             darktable.new_widget("button") {
                 tooltip = "DR200",
                 name = "film_sim_panel_dr200_button",
-                image = darktable.configuration.config_dir .. "/icons/dr200.svg",
+                image = darktable.configuration.config_dir .. "/icons/DR200.svg",
                 clicked_callback = function(source)
                     apply_style_to_selection("DR200")
                 end
@@ -208,7 +208,7 @@ darktable.register_lib(
             darktable.new_widget("button") {
                 tooltip = "DR400",
                 name = "film_sim_panel_dr400_button",
-                image = darktable.configuration.config_dir .. "/icons/dr400.svg",
+                image = darktable.configuration.config_dir .. "/icons/DR400.svg",
                 clicked_callback = function(source)
                     apply_style_to_selection("DR400")
                 end


### PR DESCRIPTION
Hi Bastian,

I'm currently having issue where the DR*** icons doesn't appear in linux.
![gh-issue-film-simulation-panel](https://github.com/user-attachments/assets/218efc37-c945-49f1-9a35-8463da9543d9)

Making this pull request to fix the dr*** paths to DR*** to resolve the issue. Paths in linux are case sensitive.

Best Regards

